### PR TITLE
fix(node): provide callback for error logging upon file write

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,12 @@ glob(options.input, (err, files) => {
         outputPath = path.resolve(options.output, filename.replace(options.basename, ''));
       }
       mkdirp.sync(path.dirname(outputPath));
-      fs.writeFile(outputPath, outFile);
+      fs.writeFile('/Users/thomascrescenzi/transvueify/example/root/shit.js', outFile, (err) => {
+        if (err) {
+          console.error(`\nError transpiling ${filename}\n`);
+          throw(err);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Prior to node v10 while a callback was required however everything would run as
expected. After node v10 a error would be thrown if no callback was provided.

fixes #3